### PR TITLE
Add offline usage examples (Node.js)

### DIFF
--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -1,0 +1,39 @@
+# RDKit for Node.js Examples
+
+The following sub-repository is dedicated to showcasing the functionalities of RDKit.js on the server-side in a Node.js environment.
+
+## Contributing
+
+First, fork the RDKit.js GitHub repository and run the remaining instructions from your fork.
+
+### Dependencies
+
+- Git
+- Node >= 14.x
+- Yarn 1.22.19
+
+### Installation and local development server
+
+Run the following command to install the RDKit.js project.
+
+```bash
+git clone https://github.com/<name of your fork>/rdkit-js.git && \
+cd rdkit-js && \
+yarn install
+```
+
+You are now ready to develop.
+
+### Contributing examples
+
+All examples are written in the `./examples/node/examples` folder.
+
+To add a new example, make sure to respect the following checklist:
+
+1. [ ] Start a new git branch from the master branch and give it a meaningful name
+2. [ ] Create a new js file in the `./examples/node/examples`, give it a meaningful name, and implement your node example in this file.
+3. [ ] Make sure you formatted your code with `npm run format`.
+
+Refer to any other react example in `examples/node/examples` if you are unusure about any of the steps above.
+
+Once you're done, make a pull request to the master branch of the main RDKit.js repository, and wait for the review!

--- a/examples/node/examples/descriptors_calculation.js
+++ b/examples/node/examples/descriptors_calculation.js
@@ -1,0 +1,7 @@
+import initRDKitModule from "@rdkit/rdkit";
+
+let rdkit = await initRDKitModule();
+let smiles = "CC(=O)Oc1ccccc1C(=O)O";
+let mol = rdkit.get_mol(smiles);
+let descriptors = JSON.parse(mol.get_descriptors());
+console.log(descriptors);

--- a/examples/node/examples/drawing_molecules_constraints.js
+++ b/examples/node/examples/drawing_molecules_constraints.js
@@ -1,0 +1,35 @@
+import initRDKitModule from "@rdkit/rdkit";
+
+let rdkit = await initRDKitModule();
+let smiles = "c1cnc(C)nc1C(=O)O";
+var mol = rdkit.get_mol(smiles);
+var template = `
+    Mrv2014 10192005332D          
+  
+    0  0  0     0  0            999 V3000
+  M  V30 BEGIN CTAB
+  M  V30 COUNTS 6 6 0 0 0
+  M  V30 BEGIN ATOM
+  M  V30 1 C -5.7917 2.5817 0 0
+  M  V30 2 N -7.1253 1.8117 0 0
+  M  V30 3 C -7.1253 0.2716 0 0
+  M  V30 4 C -5.7917 -0.4984 0 0
+  M  V30 5 C -4.458 0.2716 0 0
+  M  V30 6 N -4.458 1.8117 0 0
+  M  V30 END ATOM
+  M  V30 BEGIN BOND
+  M  V30 1 1 1 2
+  M  V30 2 2 2 3
+  M  V30 3 1 3 4
+  M  V30 4 2 4 5
+  M  V30 5 1 5 6
+  M  V30 6 2 1 6
+  M  V30 END BOND
+  M  V30 END CTAB
+  M  END
+  `;
+let qmol = RDKitModule.get_mol(template);
+mol.generate_aligned_coords(qmol, true);
+let tdetails = mol.get_substruct_match(qmol);
+let svg = mol.get_svg_with_highlights(tdetails);
+console.log(svg);

--- a/examples/node/examples/drawing_molecules_options.js
+++ b/examples/node/examples/drawing_molecules_options.js
@@ -1,0 +1,22 @@
+import initRDKitModule from "@rdkit/rdkit";
+
+let rdkit = await initRDKitModule();
+let smiles = "CC(=O)Oc1ccccc1C(=O)O";
+let mol = rdkit.get_mol(smiles);
+let smarts = "O=C";
+let qmol = rdkit.get_qmol(smarts);
+
+let mdetails = {};
+mdetails["atoms"] = [0, 1, 10];
+mdetails["explicitMethyl"] = true;
+mdetails["addAtomIndices"] = true;
+mdetails["legend"] = "aspirin";
+
+let mdetails2 = JSON.parse(mol.get_substruct_match(qmol));
+mdetails2["highlightColour"] = [1, 0, 1];
+mdetails2["legend"] = "aspirin";
+
+let svg1 = mol.get_svg_with_highlights(JSON.stringify(mdetails));
+let svg2 = mol.get_svg_with_highlights(JSON.stringify(mdetails2));
+console.log(svg1);
+console.log(svg2);

--- a/examples/node/examples/drawing_molecules_substructure.js
+++ b/examples/node/examples/drawing_molecules_substructure.js
@@ -1,0 +1,10 @@
+import initRDKitModule from "@rdkit/rdkit";
+
+let rdkit = await initRDKitModule();
+let smiles = "CC(=O)Oc1ccccc1C(=O)O";
+let mol = rdkit.get_mol(smiles);
+let smarts = "Oc1[c,n]cccc1";
+let qmol = rdkit.get_qmol(smarts);
+let mdetails = mol.get_substruct_match(qmol);
+let svg = mol.get_svg_with_highlights(mdetails);
+console.log(svg);

--- a/examples/node/examples/drawing_molecules_svg.js
+++ b/examples/node/examples/drawing_molecules_svg.js
@@ -1,0 +1,7 @@
+import initRDKitModule from "@rdkit/rdkit";
+
+let rdkit = await initRDKitModule();
+let smiles = "CC(=O)Oc1ccccc1C(=O)O";
+let mol = rdkit.get_mol(smiles);
+let svg = mol.get_svg();
+console.log(svg);

--- a/examples/node/examples/identifiers_generation.js
+++ b/examples/node/examples/identifiers_generation.js
@@ -1,0 +1,25 @@
+import initRDKitModule from "@rdkit/rdkit";
+
+let rdkit = await initRDKitModule();
+let smiles = "CC(=O)Oc1ccccc1C(=O)O";
+let mol = rdkit.get_mol(smiles);
+let identifiers = [
+  "smiles",
+  "cxsmiles",
+  "inchi",
+  "inchikey",
+  "morgan_fp",
+  "pattern_fp",
+  "aromatic_form",
+  "kekule_form",
+  "molblock",
+  "v3Kmolblock"
+];
+
+identifiers.forEach((identifier) => {
+  let val =
+    identifier === "inchikey"
+      ? rdkit.get_inchikey_for_inchi(mol.get_inchi())
+      : mol[`get_${identifier}`]();
+  console.log(`${identifier}: ${val}`);
+});

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Adding examples focusing on offline/server-side usage using Node.js (see #160).

The examples try to mirror the vanilla javascript examples in `examples/javascript`

To run an example file, run the following command:
`node <path of the example file>`