### PR TITLE
docs: update readme and types to reflect alternate wasm loading path

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,12 @@ Once you have the RDKit package installed in your node modules, copy the followi
 - `node_modules/@rdkit/rdkit/dist/RDKit_minimal.js`
 - `node_modules/@rdkit/rdkit/dist/RDKit_minimal.wasm`
 
-**NOTE: Both files must be copied at the same location in your deployed assets for the library to work properly.**
+**NOTE: By default, both files must be copied at the same location in your deployed assets for the library to work properly.**. If you need the `RDKIT_minimal.wasm` file to be loaded from another location, use the `locateFile` option when invoking `initRDKitModule`.
+
+```js
+// Load the RDKit WASM module from a specific path on your server.
+window.initRDKitModule({ locateFile: () => '/path/to/RDKit_minimal.wasm' }).then();
+```
 
 #### Option 2: Use the remote distribution files from [unpkg.com](https://unpkg.com/)
 

--- a/typescript/index.d.ts
+++ b/typescript/index.d.ts
@@ -531,11 +531,18 @@ export interface RDKitModule {
   use_legacy_stereo_perception(value: boolean): void;
 }
 
+type RDKitLoaderOptions = {
+  /**
+   * Optional path to the RDKit module .wasm file on your server.
+   */
+  locateFile?: () => string
+}
+
 /**
  * Loads the RDKit module asynchronously.
  * In order to use the RDKit module, calling this function is necessary.
  */
-export type RDKitLoader = () => Promise<RDKitModule>;
+export type RDKitLoader = (options: RDKitLoaderOptions) => Promise<RDKitModule>;
 
 declare global {
   interface Window {


### PR DESCRIPTION
For some servers, the loading script will not be in the same location as the WASM module file.

Update documentation and types to reflect how to load rdkit-js from an alternate path.

Additional context from this discussion: https://github.com/rdkit/rdkit-js/discussions/360#discussioncomment-6478625